### PR TITLE
Updates for cygwin and win32, TAP tests and Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+language: cpp
+os:
+  - linux
+  - osx
+compiler:
+  - gcc
+  - clang
+install:
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
+  - if [ "$CXX" = "clang++" ]; then export CXXFLAGS="-D__float128=void"; fi
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.9
+      - g++-4.9
+      - clang
+script: 
+  - cmake . && make && ./path_demo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,6 @@ cmake_minimum_required(VERSION 2.8)
 project(path)
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   # Enable C++11 mode on GCC / Clang
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -U__STRICT_ANSI__")
 endif()
 add_executable(path_demo path_demo.cpp filesystem/path.h filesystem/resolver.h)

--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -19,6 +19,7 @@
 #include <cerrno>
 #include <cstring>
 #include <utility>
+#include <climits>
 
 #if defined(_WIN32)
 # include <windows.h>

--- a/filesystem/path.h
+++ b/filesystem/path.h
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <utility>
 #include <climits>
+#include <cstdio>
 
 #if defined(_WIN32)
 # include <windows.h>
@@ -69,11 +70,13 @@ public:
 			, absolute(path.absolute) {
 	}
 
+#if __cplusplus >= 201103L
 	path(path &&path)
 			: type(path.type)
 			, leafs(std::move(path.leafs))
 			, absolute(path.absolute) {
 	}
+#endif
 
 	path(const char *string) {
 		this->set(string);


### PR DESCRIPTION
This pull request includes:
- fixes necessary to compile in cygwin
- fixes necessary to compile in C++98
- Travis-CI file that can be used to setup travis to compile and run the tests after every commit. For this to
  work, path_demo needs to exit 0 on success and 1 on failure.
- add TAP tests for a few of the tests
